### PR TITLE
Tiny readme suggestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 REM unit polyfill
 =================
 
-No fluff here. You can load this conditionally or just include a reference in your page. This will test for REM support, although we all know <IE8 is where the issue lies. 
+No fluff here. You can load this conditionally or just include a reference in your page. This will test for REM support, although we all know IE8 and below is where the issue lies. 
 
 An example is included that is small and you can bring up in your favorite browser to see how it works. Once lack of support is determined, the polyfill reads all links for stylesheets and finds selectors that have rules using the REM unit. It then recalculates those to PX and writes them in the head to override in the cascade. Magic.
 


### PR DESCRIPTION
Originally I wanted to change `<IE8` to `<= IE8` but this might be better. Its IE8 itself and below which need this right?. And `<IE8` reads to me like it says only the IE's below IE8.
